### PR TITLE
Using stylesheet_link_tag rails helper for MarkItUp stylesheet linking

### DIFF
--- a/lib/mark_it_up/view_helpers.rb
+++ b/lib/mark_it_up/view_helpers.rb
@@ -29,7 +29,7 @@ module MarkItUp
       inline_css = MarkItUp.markup_set.inject("") do |x,btn|
         icon = btn[:icon].blank? ? MarkItUp.default_icon : btn[:icon]
         icon.concat(".png") unless icon.match(MarkItUp::ICONS_EXTENSIONS_REGEXP)
-        x.concat(btn[:className].blank? ? "" : ".markItUp .#{btn[:className]} a {background-image:url(/#{MarkItUp.root}/icons/#{icon})}\n")
+        x.concat(btn[:className].blank? ? "" : ".markItUp .#{btn[:className]} a {background-image:url(#{image_path "/#{MarkItUp.root}/icons/#{icon}"})}\n")
       end
       css << return_html_considering_rails_version(%{
 <style type="text/css" media="all">

--- a/lib/mark_it_up/view_helpers.rb
+++ b/lib/mark_it_up/view_helpers.rb
@@ -25,18 +25,18 @@ module MarkItUp
     end
 
     def include_mark_it_up_stylesheets
-      css = %{\n<link href="/#{MarkItUp.root}/skins/#{MarkItUp.skin}/style.css" media="all" rel="stylesheet" type="text/css" />}
+      css = stylesheet_link_tag("/#{MarkItUp.root}/skins/#{MarkItUp.skin}/style.css")
       inline_css = MarkItUp.markup_set.inject("") do |x,btn|
         icon = btn[:icon].blank? ? MarkItUp.default_icon : btn[:icon]
         icon.concat(".png") unless icon.match(MarkItUp::ICONS_EXTENSIONS_REGEXP)
         x.concat(btn[:className].blank? ? "" : ".markItUp .#{btn[:className]} a {background-image:url(/#{MarkItUp.root}/icons/#{icon})}\n")
       end
-      css << %{
+      css << return_html_considering_rails_version(%{
 <style type="text/css" media="all">
 #{inline_css}
 </style>
-      }
-      return_html_considering_rails_version(css)
+      })
+      css
     end
 
     private


### PR DESCRIPTION
Hello.

I suggest to use stylesheet_link_tag instead of current solution with link tag.

It allows using rails asset_host setting and other asset pipeline things. Addditionally, it makes stylesheet link work when rails is deployed in subdirectory.
